### PR TITLE
Me routes & optional authentication

### DIFF
--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -93,7 +93,6 @@
         <SummaryInfo
           :auth_str="auth_str"
           :lookup_url="lookup_url"
-          :token="auth.token || ''"
           @start-search="searchDatasets"
         />
       </v-navigation-drawer>

--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -90,11 +90,7 @@
         temporary
         class="d-md-none"
       >
-        <SummaryInfo
-          :auth_str="auth_str"
-          :lookup_url="lookup_url"
-          @start-search="searchDatasets"
-        />
+        <SummaryInfo @start-search="searchDatasets" />
       </v-navigation-drawer>
 
       <!-- Main Content -->

--- a/dtool-lookup-webapp/src/components/SummaryInfo.vue
+++ b/dtool-lookup-webapp/src/components/SummaryInfo.vue
@@ -192,14 +192,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, getCurrentInstance } from "vue";
 import type { AxiosError, AxiosResponse } from "axios";
-import { getUsernameFromJwt } from "@/utils/jwtUtils";
 import { useStore } from "@/store";
 import type { SummaryInfo } from "@/types";
 
 const props = defineProps<{
   lookup_url: string;
   auth_str: string;
-  token: string;
 }>();
 
 const emit = defineEmits<{
@@ -213,13 +211,12 @@ const axios = instance?.appContext.config.globalProperties.$http;
 const summary_info = ref<SummaryInfo | null>(null);
 const loading = ref(true);
 const errored = ref(false);
-const username = ref("");
 const selectedTags = ref<string[]>([]);
 const selectedBaseUris = ref<string[]>([]);
 const selectedCreators = ref<string[]>([]);
 
 const source = computed(() => {
-  return props.lookup_url + "/users/" + username.value + "/summary";
+  return props.lookup_url + "/me/summary";
 });
 
 function load_summary(): void {
@@ -282,11 +279,6 @@ function toggleCreator(creator: string): void {
 }
 
 onMounted(() => {
-  if (props.token) {
-    const extractedUsername = getUsernameFromJwt(props.token);
-    username.value = extractedUsername;
-    store.updateUsername(extractedUsername);
-  }
   load_summary();
 });
 </script>

--- a/dtool-lookup-webapp/src/components/SummaryInfo.vue
+++ b/dtool-lookup-webapp/src/components/SummaryInfo.vue
@@ -190,23 +190,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, getCurrentInstance } from "vue";
-import type { AxiosError, AxiosResponse } from "axios";
+import { ref, onMounted } from "vue";
 import { useStore } from "@/store";
+import { dserverApi } from "@/services/dserverApi";
 import type { SummaryInfo } from "@/types";
-
-const props = defineProps<{
-  lookup_url: string;
-  auth_str: string;
-}>();
 
 const emit = defineEmits<{
   (e: "start-search"): void;
 }>();
 
 const store = useStore();
-const instance = getCurrentInstance();
-const axios = instance?.appContext.config.globalProperties.$http;
 
 const summary_info = ref<SummaryInfo | null>(null);
 const loading = ref(true);
@@ -215,24 +208,18 @@ const selectedTags = ref<string[]>([]);
 const selectedBaseUris = ref<string[]>([]);
 const selectedCreators = ref<string[]>([]);
 
-const source = computed(() => {
-  return props.lookup_url + "/me/summary";
-});
-
-function load_summary(): void {
+async function load_summary(): Promise<void> {
   console.log("Loading summary info");
   errored.value = false;
   loading.value = true;
-  axios
-    .get(source.value, { headers: { Authorization: props.auth_str } })
-    .then((response: AxiosResponse<SummaryInfo>) => {
-      summary_info.value = response.data;
-    })
-    .catch((error: AxiosError) => {
-      console.log(error);
-      errored.value = true;
-    })
-    .finally(() => (loading.value = false));
+  try {
+    summary_info.value = (await dserverApi.getMySummary()) as SummaryInfo;
+  } catch (error) {
+    console.log(error);
+    errored.value = true;
+  } finally {
+    loading.value = false;
+  }
 }
 
 function searchDatasets(): void {

--- a/dtool-lookup-webapp/src/components/UserMenu.vue
+++ b/dtool-lookup-webapp/src/components/UserMenu.vue
@@ -8,14 +8,14 @@
         class="user-menu-btn"
       >
         <v-icon start>mdi-account-circle</v-icon>
-        <span class="d-none d-sm-inline">{{ username || 'User' }}</span>
+        <span v-if="authEnabled" class="d-none d-sm-inline">{{ username || 'User' }}</span>
         <v-icon end>mdi-menu-down</v-icon>
       </v-btn>
     </template>
 
     <v-card min-width="280" rounded="lg">
       <!-- User info header -->
-      <div class="pa-4 pb-2">
+      <div v-if="authEnabled" class="pa-4 pb-2">
         <div class="d-flex align-center">
           <v-avatar color="primary" size="40">
             <v-icon color="white">mdi-account</v-icon>
@@ -27,7 +27,7 @@
         </div>
       </div>
 
-      <v-divider />
+      <v-divider v-if="authEnabled" />
 
       <v-list density="compact" nav>
         <!-- Server Configuration -->
@@ -63,16 +63,18 @@
           <v-list-item-title>Info</v-list-item-title>
         </v-list-item>
 
-        <v-divider class="my-1" />
+        <template v-if="authEnabled">
+          <v-divider class="my-1" />
 
-        <!-- Logout -->
-        <v-list-item
-          prepend-icon="mdi-logout"
-          base-color="error"
-          @click="logout"
-        >
-          <v-list-item-title>Logout</v-list-item-title>
-        </v-list-item>
+          <!-- Logout -->
+          <v-list-item
+            prepend-icon="mdi-logout"
+            base-color="error"
+            @click="logout"
+          >
+            <v-list-item-title>Logout</v-list-item-title>
+          </v-list-item>
+        </template>
       </v-list>
     </v-card>
   </v-menu>
@@ -151,6 +153,7 @@
 import { ref, computed } from "vue";
 import { useStore } from "@/store";
 import { useAuthStore } from "@/stores/auth";
+import { authEnabled } from "@/config";
 
 const emit = defineEmits<{
   (e: "logoutAction"): void;

--- a/dtool-lookup-webapp/src/config.ts
+++ b/dtool-lookup-webapp/src/config.ts
@@ -1,0 +1,8 @@
+/**
+ * Build-time webapp configuration flags.
+ *
+ * Centralised so views/stores import from one place rather than reading
+ * `process.env` directly.
+ */
+
+export const authEnabled = process.env.VUE_APP_AUTH_ENABLED !== "false";

--- a/dtool-lookup-webapp/src/env.d.ts
+++ b/dtool-lookup-webapp/src/env.d.ts
@@ -28,6 +28,7 @@ interface ImportMetaEnv {
   readonly VUE_APP_INFO_CONTENT?: string;
   readonly VUE_APP_DTOOL_JSON_PATH?: string;
   readonly VUE_APP_DTOOL_README_YAML_PATH?: string;
+  readonly VUE_APP_AUTH_ENABLED?: string;
 }
 
 interface ImportMeta {
@@ -54,5 +55,6 @@ declare namespace NodeJS {
     VUE_APP_INFO_CONTENT?: string;
     VUE_APP_DTOOL_JSON_PATH?: string;
     VUE_APP_DTOOL_README_YAML_PATH?: string;
+    VUE_APP_AUTH_ENABLED?: string;
   }
 }

--- a/dtool-lookup-webapp/src/services/dserverApi.ts
+++ b/dtool-lookup-webapp/src/services/dserverApi.ts
@@ -17,6 +17,7 @@ import type {
   ReadmeResponse,
   ManifestResponse,
   SummaryInfo,
+  UserWithPermissions,
   DServerError,
   AuthenticationError,
   AuthorizationError,
@@ -36,6 +37,7 @@ export type {
   ReadmeResponse,
   ManifestResponse,
   SummaryInfo,
+  UserWithPermissions,
   DServerError,
   AuthenticationError,
   AuthorizationError,
@@ -119,6 +121,14 @@ class DServerApi {
 
   async getUserSummary(username: string): Promise<SummaryInfo> {
     return this.ensureClient().getUserSummary(username);
+  }
+
+  async getMe(): Promise<UserWithPermissions> {
+    return this.ensureClient().getMe();
+  }
+
+  async getMySummary(): Promise<SummaryInfo> {
+    return this.ensureClient().getMySummary();
   }
 
   // =========================================================================

--- a/dtool-lookup-webapp/src/stores/auth.ts
+++ b/dtool-lookup-webapp/src/stores/auth.ts
@@ -10,6 +10,7 @@ import { ref, computed } from "vue";
 import { dserverApi } from "@/services/dserverApi";
 import { decodeJwt } from "@/utils/jwtUtils";
 import { useNotificationStore } from "@/stores/notifications";
+import { authEnabled } from "@/config";
 
 export type AuthStatus =
   | "idle" // Initial state, checking for existing session
@@ -81,6 +82,10 @@ export const useAuthStore = defineStore(
      * Verifies the token works by making an API call
      */
     async function login(newToken: string): Promise<boolean> {
+      if (!authEnabled) {
+        status.value = "authenticated";
+        return true;
+      }
       status.value = "idle";
       error.value = null;
 
@@ -161,6 +166,7 @@ export const useAuthStore = defineStore(
      * Logout and clear all auth state
      */
     function logout(): void {
+      if (!authEnabled) return;
       clearAuth();
       status.value = "unauthenticated";
       error.value = null;
@@ -192,6 +198,10 @@ export const useAuthStore = defineStore(
      * Called on app startup to restore session
      */
     async function checkAuth(): Promise<boolean> {
+      if (!authEnabled) {
+        status.value = "authenticated";
+        return true;
+      }
       if (!token.value) {
         status.value = "unauthenticated";
         return false;
@@ -211,6 +221,14 @@ export const useAuthStore = defineStore(
      * Initialize the store - check for existing token from URL or cookies
      */
     async function initialize(): Promise<void> {
+      if (!authEnabled) {
+        // No-auth mode: bring the API client up with no Authorization header
+        // and report the session as authenticated so the app skips the SignIn guard.
+        dserverApi.setToken("");
+        status.value = "authenticated";
+        return;
+      }
+
       // Check for token in URL (OAuth2 callback)
       const urlParams = new URLSearchParams(window.location.search);
       const tokenParam = urlParams.get("token");

--- a/dtool-lookup-webapp/tests/unit/auth.spec.ts
+++ b/dtool-lookup-webapp/tests/unit/auth.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("@/services/dserverApi", () => ({
+  dserverApi: {
+    setToken: vi.fn(),
+    searchDatasets: vi.fn(),
+  },
+}));
+
+describe("Auth store — auth disabled", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setActivePinia(createPinia());
+  });
+
+  it("initialize() reports authenticated without any network call", async () => {
+    vi.doMock("@/config", () => ({ authEnabled: false }));
+    const { useAuthStore } = await import("@/stores/auth");
+    const { dserverApi } = await import("@/services/dserverApi");
+
+    const auth = useAuthStore();
+    await auth.initialize();
+
+    expect(auth.status).toBe("authenticated");
+    expect(auth.isAuthenticated).toBe(true);
+    expect(dserverApi.setToken).toHaveBeenCalledWith("");
+    expect(dserverApi.searchDatasets).not.toHaveBeenCalled();
+  });
+
+  it("logout() is a no-op when auth is disabled", async () => {
+    vi.doMock("@/config", () => ({ authEnabled: false }));
+    const { useAuthStore } = await import("@/stores/auth");
+
+    const auth = useAuthStore();
+    await auth.initialize();
+    auth.logout();
+
+    expect(auth.status).toBe("authenticated");
+    expect(auth.isAuthenticated).toBe(true);
+  });
+
+  it("login() short-circuits to true without verifying", async () => {
+    vi.doMock("@/config", () => ({ authEnabled: false }));
+    const { useAuthStore } = await import("@/stores/auth");
+    const { dserverApi } = await import("@/services/dserverApi");
+
+    const auth = useAuthStore();
+    const ok = await auth.login("anything");
+
+    expect(ok).toBe(true);
+    expect(auth.status).toBe("authenticated");
+    expect(dserverApi.searchDatasets).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
* Makes use of dserver's /me and /me/summary routes instead of extracting the username from the token. Accompanying PR: https://github.com/livMatS/dserver-client-js/pull/2.
* Allows disabling authentication altogether with `VUE_APP_AUTH_ENABLED`. I want this option for the simple local deployment container that indexes a local directory without any authentication (https://github.com/livMatS/dserver-minimal/tree/main/docker/single-container)