### PR TITLE
CI modernization, optional-auth merge, and CLAUDE.md

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,39 +2,72 @@ name: dtool-lookup-webapp-build-and-test
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: ['16', '18']
-    name: Node ${{ matrix.node-version }} 
+        node-version: ['20', '22', '24']
+    name: Node ${{ matrix.node-version }}
     steps:
-      - name: Check out
+      - name: Check out webapp
         uses: actions/checkout@v4
+        with:
+          path: dtool-lookup-webapp
 
-      - name: Set up node
+      # dserver-client is a local file:../../dserver-client-js dependency, so the
+      # client repo must sit one level above the webapp's package.json. Checking
+      # the webapp out under dtool-lookup-webapp/ and the client under
+      # dserver-client-js/ makes file:../../dserver-client-js resolve correctly.
+      - name: Check out dserver-client-js
+        uses: actions/checkout@v4
+        with:
+          repository: livMatS/dserver-client-js
+          path: dserver-client-js
+
+      - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: dtool-lookup-webapp/dtool-lookup-webapp/package-lock.json
+
+      # Build the client first so its dist/ exists before the webapp links it.
+      # dserver-client-js ships TypeScript sources only (main/types point to
+      # dist/) and has no committed lockfile, so use npm install + build.
+      - name: Build dserver-client-js
+        working-directory: dserver-client-js
+        run: |
+          npm install
+          npm run build
 
       - name: Install dependencies
-        working-directory: ./dtool-lookup-webapp
-        run: npm install
+        working-directory: dtool-lookup-webapp/dtool-lookup-webapp
+        run: npm ci
 
       - name: Lint
-        working-directory: ./dtool-lookup-webapp
+        working-directory: dtool-lookup-webapp/dtool-lookup-webapp
         run: npm run lint src
 
+      - name: Type-check
+        working-directory: dtool-lookup-webapp/dtool-lookup-webapp
+        run: npm run type-check
+
       - name: Build
-        working-directory: ./dtool-lookup-webapp
+        working-directory: dtool-lookup-webapp/dtool-lookup-webapp
         run: npm run build
 
       - name: Run tests
-        working-directory: ./dtool-lookup-webapp
+        working-directory: dtool-lookup-webapp/dtool-lookup-webapp
         run: npm run test:unit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository layout
+
+This repo has a **nested structure**. The git root contains docs (`README.rst`,
+`SPEC.rst`, `CHANGELOG.rst`), the Ansible `provision/` deployment, and a
+placeholder `package-lock.json`. The **actual Vue application lives in the
+`dtool-lookup-webapp/` subdirectory** — all `npm` commands must run from there.
+
+```
+dtool-lookup-webapp/           # git root (docs, provision/)
+└── dtool-lookup-webapp/       # the Vue 3 SPA — cd here for all dev work
+```
+
+## Commands
+
+All commands run from the inner `dtool-lookup-webapp/` directory:
+
+```bash
+npm install              # install deps + apply .env changes
+npm run serve            # dev server (vue-cli-service)
+npm run build            # production build -> dist/ (static SPA)
+npm run lint             # eslint via vue-cli-service; CI runs `npm run lint src`
+npm run type-check       # vue-tsc --noEmit (TS type checking)
+npm run test             # vitest (watch mode)
+npm run test:unit        # vitest run (one-shot; what CI runs)
+npm run test:coverage    # vitest run --coverage
+npx vitest run tests/unit/store.spec.ts          # run a single test file
+npx vitest run -t "name of test"                 # run tests matching a name
+```
+
+CI (`.github/workflows/build-and-test.yml`) runs lint → build → test:unit on
+Node 16 and 18.
+
+## Configuration (`.env`)
+
+The app is configured **at build time** via `VUE_APP_*` environment variables in
+`dtool-lookup-webapp/.env` (not committed). `.env` changes only take effect after
+re-running `npm install` / rebuilding. Key vars:
+
+- `VUE_APP_DTOOL_LOOKUP_SERVER_URL` — dserver base URL (default `http://localhost:5000`)
+- `VUE_APP_DTOOL_LOOKUP_SERVER_TOKEN_GENERATOR_URL` — OAuth2 token endpoint (default `${serverUrl}/auth/token`)
+- `VUE_APP_DTOOL_LOOKUP_SERVER_AUTH_LOGOUT_URL` — logout endpoint (default `${serverUrl}/auth/logout`)
+- `VUE_APP_AUTH_ENABLED` — set to `"false"` to run in **no-auth mode** (default: auth on). Exposed as `authEnabled` from `@/config`; see auth flow.
+- Landing-page and user-menu customization vars (see `README.rst`)
+
+All server endpoints are resolved in a single place — **`src/config.ts`** — so a
+missing env var degrades consistently. Do not read `process.env.VUE_APP_*`
+directly elsewhere; import from `@/config`.
+
+## Architecture
+
+A single-page Vue 3 (Composition API + `<script setup>`) app using **Vuetify 3**
+for UI and **Pinia** for state. It is a pure client that talks to an external
+**dserver** (`dtool-lookup-server`) REST API. `@` is aliased to `src/`.
+
+### Backend client boundary
+
+The app never calls the dserver REST API ad hoc. It depends on the external
+**`dserver-client`** package (a local `file:../../dserver-client-js` dependency)
+and wraps it in a single service:
+
+- **`src/services/dserverApi.ts`** — exports the `dserverApi` singleton, a thin
+  typed wrapper over `DServerClient`. All dataset/search/tag/annotation/user/
+  base-URI/dependency-graph calls go through here. It also re-exports the
+  client's types and error classes. Add new server interactions as methods here.
+
+Exception: legacy **mongo queries** still go through `axios` directly to
+`${lookup_url}/mongo/query` (see `searchDatasets` in `App.vue`).
+
+### State (Pinia stores)
+
+- **`src/store.ts`** (`useStore`, id `"main"`) — search/browse state: free-text &
+  mongo query, facet filters (creator, base_uri, tags, uploaded_by), current
+  dataset + its manifest/readme/annotations/tags, pagination, sort option, server
+  versions, and `hasSignedUrlPlugin`.
+- **`src/stores/auth.ts`** (`useAuthStore`) — JWT/session lifecycle. **Persisted
+  to localStorage** (key `dtool-auth`). See auth flow below.
+- **`src/stores/serverHealth.ts`** — polls dserver health (30s interval, 5s
+  timeout); drives the "Server Unavailable" guard.
+- **`src/stores/notifications.ts`** — snackbar notifications.
+
+Pinia + `pinia-plugin-persistedstate` are registered in `src/main.ts`, which also
+defines the Vuetify `dtoolTheme` (purple) and component defaults.
+
+### Authentication flow
+
+**No-auth mode**: when `authEnabled` is `false` (`VUE_APP_AUTH_ENABLED=false`),
+`auth.ts` short-circuits — `initialize()` sets an empty token on `dserverApi` and
+reports status `"authenticated"`, while `login`/`logout`/`checkAuth` become
+no-ops. The app skips the SignIn guard entirely and relies on an open dserver.
+Everything below applies only when auth is enabled.
+
+OAuth2 via the dserver token generator; the JWT **never rides in a query param**
+(avoids leaking into history/logs). `auth.initialize()` resolves a token in
+priority order:
+
+1. **URL fragment** (`#token=...`, default OAuth2 callback mode) — consumed, then
+   the URL is cleaned via `history.replaceState`.
+2. **Cookie-only mode** — `fetchSessionToken()` GETs the token endpoint
+   `withCredentials` (used when `OAUTH2_DELIVER_TOKEN_IN_FRAGMENT=false`).
+3. **Persisted token** from localStorage.
+
+`login()` verifies the token by calling `getCurrentUser()`; a 401/403 means
+authenticated-but-not-registered → status `"unauthorized"`. Admin status and
+search/register permissions come from that response. A timer auto-logs-out at
+token expiry; `logout()` also POSTs the logout endpoint to kill the server
+session. Auth `status` (`idle`/`authenticated`/`unauthenticated`/`unauthorized`/
+`error`) gates the top-level views in `App.vue`.
+
+### App shell & views
+
+**`App.vue`** (~900 lines) is the orchestrator. It renders one of four states in
+priority order: initializing → server-unhealthy → sign-in → authenticated. The
+authenticated view switches between `currentView` `"datasets"` (browser) and
+`"users"` (admin-only `UserManagement`). It builds the `SearchQuery` from store
+filters and owns `searchDatasets()`. Components in `src/components/` are
+presentational (DatasetTable, DatasetReadme, DatasetManifest, TextSearch,
+SignIn, UserMenu, etc.) and communicate up via events like `@start-search`.
+
+Pagination relies on the server's `X-Pagination` header (flask-smorest); note the
+recent fix normalizing this header for the mongo query branch.
+
+## Deployment
+
+Production build is a static SPA served by nginx, provisioned with Ansible. Build,
+tarball `dist/`, and run the playbook per `provision/README.rst`.

--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -93,7 +93,6 @@
         <SummaryInfo
           :auth_str="auth_str"
           :lookup_url="lookup_url"
-          :token="auth.token || ''"
           @start-search="searchDatasets"
         />
       </v-navigation-drawer>

--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -90,11 +90,7 @@
         temporary
         class="d-md-none"
       >
-        <SummaryInfo
-          :auth_str="auth_str"
-          :lookup_url="lookup_url"
-          @start-search="searchDatasets"
-        />
+        <SummaryInfo @start-search="searchDatasets" />
       </v-navigation-drawer>
 
       <!-- Main Content -->

--- a/dtool-lookup-webapp/src/components/SummaryInfo.vue
+++ b/dtool-lookup-webapp/src/components/SummaryInfo.vue
@@ -192,14 +192,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, getCurrentInstance } from "vue";
 import type { AxiosError, AxiosResponse } from "axios";
-import { getUsernameFromJwt } from "@/utils/jwtUtils";
 import { useStore } from "@/store";
 import type { SummaryInfo } from "@/types";
 
 const props = defineProps<{
   lookup_url: string;
   auth_str: string;
-  token: string;
 }>();
 
 const emit = defineEmits<{
@@ -213,13 +211,12 @@ const axios = instance?.appContext.config.globalProperties.$http;
 const summary_info = ref<SummaryInfo | null>(null);
 const loading = ref(true);
 const errored = ref(false);
-const username = ref("");
 const selectedTags = ref<string[]>([]);
 const selectedBaseUris = ref<string[]>([]);
 const selectedCreators = ref<string[]>([]);
 
 const source = computed(() => {
-  return props.lookup_url + "/users/" + username.value + "/summary";
+  return props.lookup_url + "/me/summary";
 });
 
 function load_summary(): void {
@@ -282,11 +279,6 @@ function toggleCreator(creator: string): void {
 }
 
 onMounted(() => {
-  if (props.token) {
-    const extractedUsername = getUsernameFromJwt(props.token);
-    username.value = extractedUsername;
-    store.updateUsername(extractedUsername);
-  }
   load_summary();
 });
 </script>

--- a/dtool-lookup-webapp/src/components/SummaryInfo.vue
+++ b/dtool-lookup-webapp/src/components/SummaryInfo.vue
@@ -190,23 +190,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, getCurrentInstance } from "vue";
-import type { AxiosError, AxiosResponse } from "axios";
+import { ref, onMounted } from "vue";
 import { useStore } from "@/store";
+import { dserverApi } from "@/services/dserverApi";
 import type { SummaryInfo } from "@/types";
-
-const props = defineProps<{
-  lookup_url: string;
-  auth_str: string;
-}>();
 
 const emit = defineEmits<{
   (e: "start-search"): void;
 }>();
 
 const store = useStore();
-const instance = getCurrentInstance();
-const axios = instance?.appContext.config.globalProperties.$http;
 
 const summary_info = ref<SummaryInfo | null>(null);
 const loading = ref(true);
@@ -215,24 +208,18 @@ const selectedTags = ref<string[]>([]);
 const selectedBaseUris = ref<string[]>([]);
 const selectedCreators = ref<string[]>([]);
 
-const source = computed(() => {
-  return props.lookup_url + "/me/summary";
-});
-
-function load_summary(): void {
+async function load_summary(): Promise<void> {
   console.log("Loading summary info");
   errored.value = false;
   loading.value = true;
-  axios
-    .get(source.value, { headers: { Authorization: props.auth_str } })
-    .then((response: AxiosResponse<SummaryInfo>) => {
-      summary_info.value = response.data;
-    })
-    .catch((error: AxiosError) => {
-      console.log(error);
-      errored.value = true;
-    })
-    .finally(() => (loading.value = false));
+  try {
+    summary_info.value = (await dserverApi.getMySummary()) as SummaryInfo;
+  } catch (error) {
+    console.log(error);
+    errored.value = true;
+  } finally {
+    loading.value = false;
+  }
 }
 
 function searchDatasets(): void {

--- a/dtool-lookup-webapp/src/components/UserMenu.vue
+++ b/dtool-lookup-webapp/src/components/UserMenu.vue
@@ -8,14 +8,14 @@
         class="user-menu-btn"
       >
         <v-icon start>mdi-account-circle</v-icon>
-        <span class="d-none d-sm-inline">{{ username || 'User' }}</span>
+        <span v-if="authEnabled" class="d-none d-sm-inline">{{ username || 'User' }}</span>
         <v-icon end>mdi-menu-down</v-icon>
       </v-btn>
     </template>
 
     <v-card min-width="280" rounded="lg">
       <!-- User info header -->
-      <div class="pa-4 pb-2">
+      <div v-if="authEnabled" class="pa-4 pb-2">
         <div class="d-flex align-center">
           <v-avatar color="primary" size="40">
             <v-icon color="white">mdi-account</v-icon>
@@ -27,7 +27,7 @@
         </div>
       </div>
 
-      <v-divider />
+      <v-divider v-if="authEnabled" />
 
       <v-list density="compact" nav>
         <!-- Server Configuration -->
@@ -63,16 +63,18 @@
           <v-list-item-title>Info</v-list-item-title>
         </v-list-item>
 
-        <v-divider class="my-1" />
+        <template v-if="authEnabled">
+          <v-divider class="my-1" />
 
-        <!-- Logout -->
-        <v-list-item
-          prepend-icon="mdi-logout"
-          base-color="error"
-          @click="logout"
-        >
-          <v-list-item-title>Logout</v-list-item-title>
-        </v-list-item>
+          <!-- Logout -->
+          <v-list-item
+            prepend-icon="mdi-logout"
+            base-color="error"
+            @click="logout"
+          >
+            <v-list-item-title>Logout</v-list-item-title>
+          </v-list-item>
+        </template>
       </v-list>
     </v-card>
   </v-menu>
@@ -151,6 +153,7 @@
 import { ref, computed } from "vue";
 import { useStore } from "@/store";
 import { useAuthStore } from "@/stores/auth";
+import { authEnabled } from "@/config";
 
 const emit = defineEmits<{
   (e: "logoutAction"): void;

--- a/dtool-lookup-webapp/src/config.ts
+++ b/dtool-lookup-webapp/src/config.ts
@@ -1,0 +1,8 @@
+/**
+ * Build-time webapp configuration flags.
+ *
+ * Centralised so views/stores import from one place rather than reading
+ * `process.env` directly.
+ */
+
+export const authEnabled = process.env.VUE_APP_AUTH_ENABLED !== "false";

--- a/dtool-lookup-webapp/src/env.d.ts
+++ b/dtool-lookup-webapp/src/env.d.ts
@@ -28,6 +28,7 @@ interface ImportMetaEnv {
   readonly VUE_APP_INFO_CONTENT?: string;
   readonly VUE_APP_DTOOL_JSON_PATH?: string;
   readonly VUE_APP_DTOOL_README_YAML_PATH?: string;
+  readonly VUE_APP_AUTH_ENABLED?: string;
 }
 
 interface ImportMeta {
@@ -54,5 +55,6 @@ declare namespace NodeJS {
     VUE_APP_INFO_CONTENT?: string;
     VUE_APP_DTOOL_JSON_PATH?: string;
     VUE_APP_DTOOL_README_YAML_PATH?: string;
+    VUE_APP_AUTH_ENABLED?: string;
   }
 }

--- a/dtool-lookup-webapp/src/services/dserverApi.ts
+++ b/dtool-lookup-webapp/src/services/dserverApi.ts
@@ -17,6 +17,7 @@ import type {
   ReadmeResponse,
   ManifestResponse,
   SummaryInfo,
+  UserWithPermissions,
   DServerError,
   AuthenticationError,
   AuthorizationError,
@@ -36,6 +37,7 @@ export type {
   ReadmeResponse,
   ManifestResponse,
   SummaryInfo,
+  UserWithPermissions,
   DServerError,
   AuthenticationError,
   AuthorizationError,
@@ -119,6 +121,14 @@ class DServerApi {
 
   async getUserSummary(username: string): Promise<SummaryInfo> {
     return this.ensureClient().getUserSummary(username);
+  }
+
+  async getMe(): Promise<UserWithPermissions> {
+    return this.ensureClient().getMe();
+  }
+
+  async getMySummary(): Promise<SummaryInfo> {
+    return this.ensureClient().getMySummary();
   }
 
   // =========================================================================

--- a/dtool-lookup-webapp/src/stores/auth.ts
+++ b/dtool-lookup-webapp/src/stores/auth.ts
@@ -10,6 +10,7 @@ import { ref, computed } from "vue";
 import { dserverApi } from "@/services/dserverApi";
 import { decodeJwt } from "@/utils/jwtUtils";
 import { useNotificationStore } from "@/stores/notifications";
+import { authEnabled } from "@/config";
 
 export type AuthStatus =
   | "idle" // Initial state, checking for existing session
@@ -81,6 +82,10 @@ export const useAuthStore = defineStore(
      * Verifies the token works by making an API call
      */
     async function login(newToken: string): Promise<boolean> {
+      if (!authEnabled) {
+        status.value = "authenticated";
+        return true;
+      }
       status.value = "idle";
       error.value = null;
 
@@ -161,6 +166,7 @@ export const useAuthStore = defineStore(
      * Logout and clear all auth state
      */
     function logout(): void {
+      if (!authEnabled) return;
       clearAuth();
       status.value = "unauthenticated";
       error.value = null;
@@ -192,6 +198,10 @@ export const useAuthStore = defineStore(
      * Called on app startup to restore session
      */
     async function checkAuth(): Promise<boolean> {
+      if (!authEnabled) {
+        status.value = "authenticated";
+        return true;
+      }
       if (!token.value) {
         status.value = "unauthenticated";
         return false;
@@ -211,6 +221,14 @@ export const useAuthStore = defineStore(
      * Initialize the store - check for existing token from URL or cookies
      */
     async function initialize(): Promise<void> {
+      if (!authEnabled) {
+        // No-auth mode: bring the API client up with no Authorization header
+        // and report the session as authenticated so the app skips the SignIn guard.
+        dserverApi.setToken("");
+        status.value = "authenticated";
+        return;
+      }
+
       // Check for token in URL (OAuth2 callback)
       const urlParams = new URLSearchParams(window.location.search);
       const tokenParam = urlParams.get("token");

--- a/dtool-lookup-webapp/tests/unit/auth.spec.ts
+++ b/dtool-lookup-webapp/tests/unit/auth.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("@/services/dserverApi", () => ({
+  dserverApi: {
+    setToken: vi.fn(),
+    searchDatasets: vi.fn(),
+  },
+}));
+
+describe("Auth store — auth disabled", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setActivePinia(createPinia());
+  });
+
+  it("initialize() reports authenticated without any network call", async () => {
+    vi.doMock("@/config", () => ({ authEnabled: false }));
+    const { useAuthStore } = await import("@/stores/auth");
+    const { dserverApi } = await import("@/services/dserverApi");
+
+    const auth = useAuthStore();
+    await auth.initialize();
+
+    expect(auth.status).toBe("authenticated");
+    expect(auth.isAuthenticated).toBe(true);
+    expect(dserverApi.setToken).toHaveBeenCalledWith("");
+    expect(dserverApi.searchDatasets).not.toHaveBeenCalled();
+  });
+
+  it("logout() is a no-op when auth is disabled", async () => {
+    vi.doMock("@/config", () => ({ authEnabled: false }));
+    const { useAuthStore } = await import("@/stores/auth");
+
+    const auth = useAuthStore();
+    await auth.initialize();
+    auth.logout();
+
+    expect(auth.status).toBe("authenticated");
+    expect(auth.isAuthenticated).toBe(true);
+  });
+
+  it("login() short-circuits to true without verifying", async () => {
+    vi.doMock("@/config", () => ({ authEnabled: false }));
+    const { useAuthStore } = await import("@/stores/auth");
+    const { dserverApi } = await import("@/services/dserverApi");
+
+    const auth = useAuthStore();
+    const ok = await auth.login("anything");
+
+    expect(ok).toBe(true);
+    expect(auth.status).toBe("authenticated");
+    expect(dserverApi.searchDatasets).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Bundles three changes that currently sit ahead of `master`.

## 1. CI: Modernize `build-and-test` workflow (`f6a3a73`)

The workflow had been failing since the OAuth2 rewrite introduced the `file:../../dserver-client-js` local dependency (never provided in CI) and its Node matrix targeted only EOL versions (16, 18).

- **Resolve the `dserver-client` dependency**: check out `livMatS/dserver-client-js` (default branch) alongside the webapp so `file:../../dserver-client-js` resolves — webapp under `dtool-lookup-webapp/`, client under `dserver-client-js/`.
- **Build the client first**: it ships TypeScript sources only (`main`/`types` → `dist/`) and has no lockfile, so the step uses `npm install` + `npm run build` (tsup) before the webapp links it.
- **Node matrix → `20`, `22`, `24`** (active LTS/current); drop EOL `16`/`18`; `fail-fast: false`.
- **`npm ci`** for the webapp (lockfile committed) + **npm caching**.
- **Add the missing `type-check`** (`vue-tsc`) step.
- **Hardening**: least-privilege `permissions: contents: read` and a `concurrency` group that cancels superseded runs.

Verified locally with [`act`](https://github.com/nektos/act) (`catthehacker/ubuntu:act-latest`, Node 20): every step passes, 16 unit tests green. The green type-check also confirms the webapp's `getMe`/`getMySummary`/`UserWithPermissions` usage matches the client's current API.

## 2. Merge `2026-05-28-optional-authentication` (`2101baa`)

Adds an optional no-auth mode (`VUE_APP_AUTH_ENABLED=false`) and switches the summary panel to `dserverApi.getMySummary()`. Resolved conflicts against master's OAuth2 fragment/cookie token flow, async server-session logout, and uploader facet; layered the `!authEnabled` guards into `login`/`logout`/`checkAuth`/`initialize`.

## 3. Add `CLAUDE.md` (`efc7f77`)

Repo guidance: nested layout, npm/test/lint commands, build-time `.env` config, architecture (dserverApi boundary, Pinia stores, auth flow incl. no-auth mode).

## Notes

- The client is tracked at its **default branch** (not pinned); a future change could pin a `ref:` for reproducibility.
- Only Node 20 was exercised locally; 22/24 use identical steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)